### PR TITLE
Add a tip on using dental floss to cut out cinnamon rolls

### DIFF
--- a/extra-special-cinnamon-rolls.md
+++ b/extra-special-cinnamon-rolls.md
@@ -9,6 +9,7 @@
 * Put eggs in a bowl of warm-hot tap water to bring to room temp.
 * Keep the dough warm but not hot when you are working with it and letting it stand.  Yeast doesn't like to be cold.
 * You can use all purpose, but I find that bread flour works better
+* Use dental floss to cut the rolled up dough - slide under, wrap around and pull together to make a nice clean cut.
 * **This is a huge recipe.  You can 1/2 it (I usually do)** 
 
 ##Rolls


### PR DESCRIPTION
This commit simply adds a useful tip to cut up the rolled up dough.
Often using a knife can pinch the dough whereas using dental floss and
provides for a nice clean cut.

Typically on a floured surface you can slide the 1.5' length of floss
under the rolled up dough and wrap around and pull together to cut the
dough into rolls.

This is best done to first cut the roll in half then keep halving it
into smaller rolls.